### PR TITLE
Klargjør app for ny versjon av rapbase

### DIFF
--- a/R/app_norscir.R
+++ b/R/app_norscir.R
@@ -1528,12 +1528,14 @@ server_norscir <- function(input, output, session) {
 
   #----------- Eksport ----------------
   ## brukerkontroller
-  rapbase::exportUCServer("norscirExport",
-                          registryName = 'norscir', #i dbConfig
-                          repoName = 'nordicscir') #pakke, for tilhørighet på github
+  rapbase::exportUCServer(
+    "norscirExport",
+    "norscir", # databasenavn
+    "nordicscir" # navn på team, for tilhørighet på github
+  )
   ## veileding
   rapbase::exportGuideServer("norscirExportGuide",
-                             registryName = 'norscir')
+                             "norscir")
 }
 # Run the application
 #shiny::shinyApp(ui = ui_norscir, server = server_norscir)


### PR DESCRIPTION
exportUCServer og exportGuideServer skal få nye navn på variabler, som samsvarer med hva de er. Dropper derfor eksplisitt variabelnavn i kall. Se Rapporteket/rapbase#347